### PR TITLE
add patches:HIVE-15859 HIVE-10458 HIVE-13293 HIVE-16600

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkPlanGenerator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkPlanGenerator.java
@@ -200,9 +200,9 @@ public class SparkPlanGenerator {
         "AssertionError: SHUFFLE_NONE should only be used for UnionWork.");
     SparkShuffler shuffler;
     if (edge.isMRShuffle()) {
-      shuffler = new SortByShuffler(false);
+      shuffler = new SortByShuffler(false, sparkPlan);
     } else if (edge.isShuffleSort()) {
-      shuffler = new SortByShuffler(true);
+      shuffler = new SortByShuffler(true, sparkPlan);
     } else {
       shuffler = new GroupByShuffler();
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplication.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplication.java
@@ -490,7 +490,7 @@ public class ReduceSinkDeDuplication implements Transform {
       if (pRS != null && merge(cRS, pRS, dedupCtx.minReducer())) {
         CorrelationUtilities.replaceReduceSinkWithSelectOperator(
             cRS, dedupCtx.getPctx(), dedupCtx);
-        pRS.getConf().setEnforceSort(true);
+        pRS.getConf().setDeduplicated(true);
         return true;
       }
       return false;
@@ -513,7 +513,7 @@ public class ReduceSinkDeDuplication implements Transform {
       if (pRS != null && merge(cRS, pRS, dedupCtx.minReducer())) {
         CorrelationUtilities.removeReduceSinkForGroupBy(
             cRS, cGBY, dedupCtx.getPctx(), dedupCtx);
-        pRS.getConf().setEnforceSort(true);
+        pRS.getConf().setDeduplicated(true);
         return true;
       }
       return false;
@@ -536,7 +536,7 @@ public class ReduceSinkDeDuplication implements Transform {
             CorrelationUtilities.findPossibleParent(
                 pJoin, ReduceSinkOperator.class, dedupCtx.trustScript());
         if (pRS != null) {
-          pRS.getConf().setEnforceSort(true);
+          pRS.getConf().setDeduplicated(true);
         }
         return true;
       }
@@ -560,7 +560,7 @@ public class ReduceSinkDeDuplication implements Transform {
             CorrelationUtilities.findPossibleParent(
                 pJoin, ReduceSinkOperator.class, dedupCtx.trustScript());
         if (pRS != null) {
-          pRS.getConf().setEnforceSort(true);
+          pRS.getConf().setDeduplicated(true);
         }
         return true;
       }
@@ -580,7 +580,7 @@ public class ReduceSinkDeDuplication implements Transform {
       if (pRS != null && merge(cRS, pRS, dedupCtx.minReducer())) {
         CorrelationUtilities.replaceReduceSinkWithSelectOperator(
             cRS, dedupCtx.getPctx(), dedupCtx);
-        pRS.getConf().setEnforceSort(true);
+        pRS.getConf().setDeduplicated(true);
         return true;
       }
       return false;
@@ -597,7 +597,7 @@ public class ReduceSinkDeDuplication implements Transform {
               start, ReduceSinkOperator.class, dedupCtx.trustScript());
       if (pRS != null && merge(cRS, pRS, dedupCtx.minReducer())) {
         CorrelationUtilities.removeReduceSinkForGroupBy(cRS, cGBY, dedupCtx.getPctx(), dedupCtx);
-        pRS.getConf().setEnforceSort(true);
+        pRS.getConf().setDeduplicated(true);
         return true;
       }
       return false;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/spark/SetSparkReducerParallelism.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/spark/SetSparkReducerParallelism.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.optimizer.spark;
 
+import java.util.List;
 import java.util.Stack;
 
 import org.apache.commons.logging.Log;
@@ -26,8 +27,10 @@ import org.apache.hadoop.hive.common.ObjectPair;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.hive.ql.exec.LimitOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
+import org.apache.hadoop.hive.ql.exec.TerminalOperator;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.spark.SparkUtilities;
 import org.apache.hadoop.hive.ql.exec.spark.session.SparkSession;
@@ -75,7 +78,7 @@ public class SetSparkReducerParallelism implements NodeProcessor {
 
     context.getVisitedReduceSinks().add(sink);
 
-    if (desc.getNumReducers() <= 0) {
+    if (needSetParallelism(sink, context.getConf())) {
       if (constantReducers > 0) {
         LOG.info("Parallelism for reduce sink " + sink + " set by user to " + constantReducers);
         desc.setNumReducers(constantReducers);
@@ -155,6 +158,42 @@ public class SetSparkReducerParallelism implements NodeProcessor {
       LOG.info("Number of reducers determined to be: " + desc.getNumReducers());
     }
 
+    return false;
+  }
+
+  // tests whether the RS needs automatic setting parallelism
+  private boolean needSetParallelism(ReduceSinkOperator reduceSink, HiveConf hiveConf) {
+    ReduceSinkDesc desc = reduceSink.getConf();
+    if (desc.getNumReducers() <= 0) {
+      return true;
+    }
+    if (desc.getNumReducers() == 1 && desc.hasOrderBy() &&
+        hiveConf.getBoolVar(HiveConf.ConfVars.HIVESAMPLINGFORORDERBY) && !desc.isDeduplicated()) {
+      Stack<Operator<? extends OperatorDesc>> descendants = new Stack<Operator<? extends OperatorDesc>>();
+      List<Operator<? extends OperatorDesc>> children = reduceSink.getChildOperators();
+      if (children != null) {
+        for (Operator<? extends OperatorDesc> child : children) {
+          descendants.push(child);
+        }
+      }
+      while (descendants.size() != 0) {
+        Operator<? extends OperatorDesc> descendant = descendants.pop();
+        //If the decendants contains LimitOperator,return false
+        if (descendant instanceof LimitOperator) {
+          return false;
+        }
+        boolean reachTerminalOperator = (descendant instanceof TerminalOperator);
+        if (!reachTerminalOperator) {
+          List<Operator<? extends OperatorDesc>> childrenOfDescendant = descendant.getChildOperators();
+          if (childrenOfDescendant != null) {
+            for (Operator<? extends OperatorDesc> childOfDescendant : childrenOfDescendant) {
+              descendants.push(childOfDescendant);
+            }
+          }
+        }
+      }
+      return true;
+    }
     return false;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/spark/GenSparkUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/spark/GenSparkUtils.java
@@ -399,7 +399,7 @@ public class GenSparkUtils {
    */
   private static boolean groupByNeedParLevelOrder(ReduceSinkOperator reduceSinkOperator) {
     // whether we have to enforce sort anyway, e.g. in case of RS deduplication
-    if (reduceSinkOperator.getConf().isEnforceSort()) {
+    if (reduceSinkOperator.getConf().isDeduplicated()) {
       return true;
     }
     List<Operator<? extends OperatorDesc>> children = reduceSinkOperator.getChildOperators();

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceSinkDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceSinkDesc.java
@@ -111,8 +111,9 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
   // Write type, since this needs to calculate buckets differently for updates and deletes
   private AcidUtils.Operation writeType;
 
-  // whether we'll enforce the sort order of the RS
-  private transient boolean enforceSort = false;
+  // whether this RS is deduplicated
+  private transient boolean isDeduplicated = false;
+
 
   // used by spark mode to decide whether global order is needed
   private transient boolean hasOrderBy = false;
@@ -171,7 +172,7 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
     desc.setStatistics(this.getStatistics());
     desc.setSkipTag(skipTag);
     desc.reduceTraits = reduceTraits.clone();
-    desc.setEnforceSort(enforceSort);
+    desc.setDeduplicated(isDeduplicated);
     desc.setHasOrderBy(hasOrderBy);
     return desc;
   }
@@ -416,12 +417,12 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
     return writeType;
   }
 
-  public boolean isEnforceSort() {
-    return enforceSort;
+  public boolean isDeduplicated() {
+    return isDeduplicated;
   }
 
-  public void setEnforceSort(boolean isDeduplicated) {
-    this.enforceSort = isDeduplicated;
+  public void setDeduplicated(boolean isDeduplicated) {
+    this.isDeduplicated = isDeduplicated;
   }
 
   public boolean hasOrderBy() {

--- a/spark-client/src/main/java/org/apache/hive/spark/client/rpc/Rpc.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/rpc/Rpc.java
@@ -221,7 +221,6 @@ public class Rpc implements Closeable {
   private final Channel channel;
   private final Collection<Listener> listeners;
   private final EventExecutorGroup egroup;
-  private final Object channelLock;
   private volatile RpcDispatcher dispatcher;
 
   private Rpc(RpcConfiguration config, Channel channel, EventExecutorGroup egroup) {
@@ -229,7 +228,6 @@ public class Rpc implements Closeable {
     Preconditions.checkArgument(egroup != null);
     this.config = config;
     this.channel = channel;
-    this.channelLock = new Object();
     this.dispatcher = null;
     this.egroup = egroup;
     this.listeners = Lists.newLinkedList();
@@ -272,13 +270,13 @@ public class Rpc implements Closeable {
    * @param retType Type of expected reply.
    * @return A future used to monitor the operation.
    */
-  public <T> Future<T> call(Object msg, Class<T> retType) {
+  public <T> Future<T> call(final Object msg, Class<T> retType) {
     Preconditions.checkArgument(msg != null);
     Preconditions.checkState(channel.isActive(), "RPC channel is closed.");
     try {
       final long id = rpcId.getAndIncrement();
       final Promise<T> promise = createPromise();
-      ChannelFutureListener listener = new ChannelFutureListener() {
+      final ChannelFutureListener listener = new ChannelFutureListener() {
           @Override
           public void operationComplete(ChannelFuture cf) {
             if (!cf.isSuccess() && !promise.isDone()) {
@@ -291,10 +289,13 @@ public class Rpc implements Closeable {
       };
 
       dispatcher.registerRpc(id, promise, msg.getClass().getName());
-      synchronized (channelLock) {
-        channel.write(new MessageHeader(id, Rpc.MessageType.CALL)).addListener(listener);
-        channel.writeAndFlush(msg).addListener(listener);
-      }
+      channel.eventLoop().submit(new Runnable() {
+        @Override
+        public void run() {
+          channel.write(new MessageHeader(id, Rpc.MessageType.CALL)).addListener(listener);
+          channel.writeAndFlush(msg).addListener(listener);
+        }
+      });
       return promise;
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/spark-client/src/main/java/org/apache/hive/spark/client/rpc/RpcDispatcher.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/rpc/RpcDispatcher.java
@@ -152,12 +152,7 @@ public abstract class RpcDispatcher extends SimpleChannelInboundHandler<Object> 
 
   @Override
   public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(String.format("[%s] Caught exception in channel pipeline.", name()), cause);
-    } else {
-      LOG.info("[{}] Closing channel due to exception in pipeline ({}).", name(),
-          cause.getMessage());
-    }
+    LOG.error(String.format("[%s] Closing channel due to exception in pipeline.", name()), cause);
 
     if (lastHeader != null) {
       // There's an RPC waiting for a reply. Exception was most probably caught while processing


### PR DESCRIPTION
this PR resolves below issues, which is occurred with CDH on large data scale. The PR improves the stability as well as the performance for CDH, which has been tested under large data scale and high pressure.
HIVE-15859(HoS: Write RPC messages in event loop)
HIVE-10458( Enable parallel order by for spark [Spark Branch
HIVE-13293(Cache RDD to improve parallel order by performance for HoS)
HIVE-16600(Refactor SetSparkReducerParallelism#needSetParallelism to enable parallel order by in   multi_insert cases)

